### PR TITLE
Use new conda-forge version of ISCE that includes autoRIFT v1.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.source="https://github.com/asfadmin/hyp3-autorift
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=true
 
-RUN apt-get update && apt-get install -y --no-install-recommends unzip vim && \
+RUN apt-get update && apt-get install -y --no-install-recommends libgl1-mesa-glx unzip vim && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ARG CONDA_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ COPY conda-env.yml /home/conda/conda-env.yml
 
 RUN conda env create -f conda-env.yml && \
     conda clean -afy && \
-    conda activate hyp3-insar-isce && \
-    sed -i 's/conda activate base/conda activate hyp3-insar-isce/g' /home/conda/.profile
+    conda activate hyp3-autorift && \
+    sed -i 's/conda activate base/conda activate hyp3-autorift/g' /home/conda/.profile
 
 ARG S3_PYPI_HOST
 ARG SDIST_SPEC

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM continuumio/miniconda3:4.7.12
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md
@@ -19,59 +19,30 @@ LABEL org.opencontainers.image.source="https://github.com/asfadmin/hyp3-autorift
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONDONTWRITEBYTECODE=true
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y software-properties-common && \
-    add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && apt-get update && \
-    apt-get install -y --no-install-recommends unzip vim wget curl build-essential cmake \
-    gfortran imagemagick libatlas-base-dev gdal-bin libgdal-dev \
-    libavcodec-dev libavformat-dev libfftw3-dev libgl1-mesa-dev libgtk-3-dev \
-    libhdf5-dev libjpeg-dev libmotif-dev libpng-dev libswscale-dev libtiff-dev \
-    libv4l-dev libx264-dev libxvidcore-dev pkg-config python3-dev python3-h5py \
-    python3-matplotlib python3-pip python3-scipy scons cython3 && \
+RUN apt-get update && apt-get install -y --no-install-recommends unzip vim && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN cd /opt && wget https://github.com/opencv/opencv/archive/3.4.7.tar.gz -O opencv-3.4.7.tar.gz && \
-    wget https://github.com/opencv/opencv_contrib/archive/3.4.7.tar.gz -O opencv_contrib-3.4.7.tar.gz && \
-    tar -zxvf opencv-3.4.7.tar.gz && tar -zxvf opencv_contrib-3.4.7.tar.gz && \
-    export OPENCV_CONTRIB_MODULES=/opt/opencv_contrib-3.4.7/modules && \
-    mkdir opencv-3.4.7/_build opencv-3.4.7/_release && cd opencv-3.4.7/_build && \
-    cmake -D CMAKE_BUILD_TYPE=RELEASE \
-      -D CMAKE_INSTALL_PREFIX=/usr/local \
-      -D INSTALL_PYTHON_EXAMPLES=ON \
-      -D OPENCV_EXTRA_MODULES_PATH=${OPENCV_CONTRIB_MODULES} \
-      -D PYTHON_EXECUTABLE=$(which python3) \
-      -D BUILD_EXAMPLES=ON \
-      .. && \
-      make -j4 install && cd /opt && ldconfig
-
-RUN pip3 install --no-cache-dir --upgrade pip setuptools wheel && \
-    python3 -m pip install --no-cache-dir --upgrade numpy scipy statsmodels scikit-image
 
 ARG CONDA_UID=1000
 ARG CONDA_GID=1000
 
-RUN cd /opt && \
-    wget https://github.com/isce-framework/isce2/archive/v2.3.3.tar.gz -O isce2-2.3.3.tar.gz && \
-    tar -zxvf isce2-2.3.3.tar.gz && \
-    wget https://github.com/leiyangleon/autoRIFT/archive/v1.0.4.tar.gz -O autoRIFT-1.0.4.tar.gz && \
-    tar -zxvf autoRIFT-1.0.4.tar.gz && \
-    cp -r autoRIFT-1.0.4/geo_autoRIFT isce2-2.3.3/contrib/ && \
-    mkdir /opt/isce2-2.3.3/_scons /opt/isce2-2.3.3/_build
+RUN groupadd -g "${CONDA_GID}" --system conda && \
+    useradd -l -u "${CONDA_UID}" -g "${CONDA_GID}" --system -d /home/conda -m  -s /bin/bash conda && \
+    conda update -n base -c defaults conda && \
+    chown -R conda:conda /opt && \
+    conda clean -afy && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> /home/conda/.profile && \
+    echo "conda activate base" >> /home/conda/.profile
 
-COPY hyp3_autorift/etc/SConfigISCE /opt/isce2-2.3.3/_scons/
+USER ${CONDA_UID}
+SHELL ["/bin/bash", "-l", "-c"]
+WORKDIR /home/conda
 
-RUN export ISCE_SRC_ROOT=/opt/isce2-2.3.3 && cd ${ISCE_SRC_ROOT} && \
-    export SCONS_CONFIG_DIR=${ISCE_SRC_ROOT}/_scons && \
-    export PYTHON_SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])") && \
-    export PYTHON_INCLUDE_DIR=$(python3 -c "from sysconfig import get_paths; print(get_paths()['include'])") && \
-    export NUMPY_INCLUDE_DIR=$(python3 -c "import numpy; print(numpy.get_include())") && \
-    scons install && \
-    mkdir -p ${PYTHON_SITE_PACKAGES}/isce/helper && \
-    touch ${PYTHON_SITE_PACKAGES}/isce/helper/completed && \
-    mkdir -p /usr/local/share/isce2 && \
-    cp -r contrib/stack/* /usr/local/share/isce2 && \
-    cp -r contrib/timeseries/* /usr/local/share/isce2 && \
-    cd /opt && rm -rf opencv-3.4.7.tar.gz opencv-3.4.7/ opencv_contrib-3.4.7.tar.gz opencv_contrib-3.4.7/ && \
-    rm -rf isce2-2.3.3.tar.gz isce2-2.3.3/ autoRIFT-1.0.4.tar.gz  autoRIFT-1.0.4/
+COPY conda-env.yml /home/conda/conda-env.yml
+
+RUN conda env create -f conda-env.yml && \
+    conda clean -afy && \
+    conda activate hyp3-insar-isce && \
+    sed -i 's/conda activate base/conda activate hyp3-insar-isce/g' /home/conda/.profile
 
 ARG S3_PYPI_HOST
 ARG SDIST_SPEC
@@ -80,17 +51,5 @@ RUN python3 -m pip install --no-cache-dir hyp3_autorift${SDIST_SPEC} \
     --trusted-host "${S3_PYPI_HOST}" \
     --extra-index-url "http://${S3_PYPI_HOST}"
 
-RUN groupadd -g "${CONDA_GID}" --system conda && \
-    useradd -l -u "${CONDA_UID}" -g "${CONDA_GID}" --system -d /home/conda -m  -s /bin/bash conda && \
-    chown -R conda:conda /opt && \
-    export PYTHON_SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])") && \
-    echo "export ISCE_HOME=${PYTHON_SITE_PACKAGES}/isce" >> /home/conda/.bashrc && \
-    echo "export ISCE_STACK=${PYTHON_SITE_PACKAGES}/share/isce2" >> /home/conda/.bashrc && \
-    echo "export PATH=${PATH}:${PYTHON_SITE_PACKAGES}/isce/bin:${PYTHON_SITE_PACKAGES}/isce/applications" >> /home/conda/.bashrc
-
-USER ${CONDA_UID}
-SHELL ["/bin/bash", "-l", "-c"]
-WORKDIR /home/conda
-
-ENTRYPOINT ["/usr/local/bin/hyp3_autorift"]
+ENTRYPOINT ["conda", "run", "-n", "hyp3-autorift", "hyp3_autorift"]
 CMD ["-h"]

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -21,11 +21,14 @@ dependencies:
   - matplotlib
   - netCDF4
   - numpy
+  - opencv=3.4
+  - libopencv=3.4
   - pillow
   - proj
   - psycopg2
   - pyshp
   - requests
+  - scikit-image
   - scipy
   - six
   - statsmodels

--- a/hyp3_autorift/__main__.py
+++ b/hyp3_autorift/__main__.py
@@ -41,7 +41,7 @@ def hyp3_process(cfg, n):
         log.debug(f'FTD dir is: {cfg["ftd"]}')
 
         autorift_args = [f'{g1}.zip', f'{g2}.zip', '--process-dir', f'{cfg["ftd"]}', '--download']
-        if extra_arg_is(cfg, 'intermediate_files', 'yes'):
+        if not extra_arg_is(cfg, 'intermediate_files', 'no'):  # handle processes b4 option added
             autorift_args.append('--product')
 
         process(cfg, 'autorift_proc_pair', autorift_args)

--- a/hyp3_autorift/__main__.py
+++ b/hyp3_autorift/__main__.py
@@ -49,6 +49,10 @@ def hyp3_process(cfg, n):
         out_name = build_output_name_pair(g1, g2, cfg['workdir'], cfg['suffix'])
         log.info(f'Output name: {out_name}')
 
+        # TODO:
+        #  * browse images
+        #  * citation
+        #  * phase_png (?)
         if extra_arg_is(cfg, 'intermediate_files', 'no'):
             product_glob = os.path.join(cfg['workdir'], cfg['ftd'], '*.nc')
             netcdf_files = glob.glob(product_glob)
@@ -62,7 +66,7 @@ def hyp3_process(cfg, n):
                 raise Exception('Processing failed! Too many netCDF files found')
 
             product_file = f'{out_name}.nc'
-            os.rename(netcdf_files[0], out_name)
+            os.rename(netcdf_files[0], product_file)
 
         else:
             tmp_product_dir = os.path.join(cfg['workdir'], 'PRODUCT')
@@ -80,11 +84,6 @@ def hyp3_process(cfg, n):
 
             log.debug('Renaming ' + tmp_product_dir + ' to ' + product_dir)
             os.rename(tmp_product_dir, product_dir)
-
-            # TODO:
-            #  * browse images
-            #  * citation
-            #  * phase_png (?)
 
             zip_dir(product_dir, product_file)
 

--- a/hyp3_autorift/geometry.py
+++ b/hyp3_autorift/geometry.py
@@ -101,7 +101,7 @@ def bounding_box(safe, priority='master', polarization='hh', orbits='Orbits', au
 def find_jpl_dem(lat_limits, lon_limits, z_limits=(-200, 4000), dem_dir='DEM', download=False):
 
     if download:
-        fetch_jpl_tifs(dem_dir=dem_dir)
+        fetch_jpl_tifs(dem_dir=dem_dir, match='_h.tif')
 
     dems = glob.glob(os.path.join(dem_dir, '*_h.tif'))
 

--- a/hyp3_autorift/io.py
+++ b/hyp3_autorift/io.py
@@ -17,13 +17,28 @@ _FILE_LIST = [
     'ANT240m_dhdx.tif',
     'ANT240m_dhdy.tif',
     'ANT240m_h.tif',
+    'ANT240m_StableSurface.tif',
     'ANT240m_vx0.tif',
+    'ANT240m_vxSearchRange.tif',
     'ANT240m_vy0.tif',
+    'ANT240m_vySearchRange.tif',
+    'ANT240m_xMaxChipSize.tif',
+    'ANT240m_xMinChipSize.tif',
+    'ANT240m_yMaxChipSize.tif',
+    'ANT240m_yMinChipSize.tif',
     'GRE240m_dhdx.tif',
     'GRE240m_dhdy.tif',
     'GRE240m_h.tif',
+    'GRE240m_StableSurface.tif',
     'GRE240m_vx0.tif',
+    'GRE240m_vxSearchRange.tif',
     'GRE240m_vy0.tif',
+    'GRE240m_vySearchRange.tif',
+    'GRE240m_xMaxChipSize.tif',
+    'GRE240m_xMinChipSize.tif',
+    'GRE240m_yMaxChipSize.tif',
+    'GRE240m_yMinChipSize.tif',
+
 ]
 
 
@@ -39,7 +54,7 @@ def _request_file(url_file_map):
 
 
 def fetch_jpl_tifs(dem_dir='DEM', endpoint_url='http://jpl.nasa.gov.s3.amazonaws.com/',
-                   bucket='its-live-data', prefix='isce_autoRIFT'):
+                   bucket='its-live-data', prefix='isce_autoRIFT', match=None):
     # FIXME: Can't figure out how to get these tifs with boto3, so using requests
     # import boto3
     # from botocore import UNSIGNED
@@ -50,9 +65,15 @@ def fetch_jpl_tifs(dem_dir='DEM', endpoint_url='http://jpl.nasa.gov.s3.amazonaws
 
     log.info("Downloading tifs from JPL's AWS bucket")
     mkdir_p(dem_dir)
+
+    if match:
+        file_list = [file for file in _FILE_LIST if match in file]
+    else:
+        file_list = _FILE_LIST
+
     url_file_map = [
         (endpoint_url.replace('http://', f'http://{bucket}.') + f'{prefix}/{file}',
-         os.path.join(dem_dir, file)) for file in _FILE_LIST
+         os.path.join(dem_dir, file)) for file in file_list
     ]
 
     pool = Pool(5)

--- a/hyp3_autorift/vend/CHANGES.diff
+++ b/hyp3_autorift/vend/CHANGES.diff
@@ -1,265 +1,8 @@
-diff --git a/hyp3_autorift/vend/testGeogrid_ISCE.py b/hyp3_autorift/vend/testGeogrid_ISCE.py
-index 04d10c7..40caae1 100755
---- a/hyp3_autorift/vend/testGeogrid_ISCE.py
-+++ b/hyp3_autorift/vend/testGeogrid_ISCE.py
-@@ -1,6 +1,11 @@
+--- testautoRIFT_ISCE.orig.py	2020-06-26 08:52:27.311909308 -0800
++++ testautoRIFT_ISCE.py	2020-06-26 09:39:41.777619916 -0800
+@@ -1,6 +1,12 @@
  #!/usr/bin/env python3
--
--#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+# This is a substantially modified copy of the testGeogrid_ISCE.py script
-+# as described in the README.md in this directory. See the LICENSE file in this
-+# directory for the original terms and conditions, and CHANGES.diff for a detailed
-+# description of the changes. Notice, all changes are released under the terms
-+# and conditions of hyp3-autorift's LICENSE.
-+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- # Copyright 2019 California Institute of Technology. ALL RIGHTS RESERVED.
- #
- # Licensed under the Apache License, Version 2.0 (the "License");
-@@ -25,37 +30,47 @@
- # embargoed foreign country or citizen of those countries.
- #
- # Authors: Piyush Agram, Yang Lei
--#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+import argparse
-+import os
-+
-+import numpy as np
-+from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
-+from isce.components.contrib.geo_autoRIFT.geogrid import GeogridOptical
-+from isce.components.isceobj.Orbit.Orbit import Orbit
-+from isce.components.iscesys.Component.ProductManager import ProductManager as PM
-+from osgeo import gdal
  
- 
- def cmdLineParse():
-     '''
-     Command line parser.
-     '''
--    import argparse
--
-     parser = argparse.ArgumentParser(description='Output geo grid')
-     parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
--            help='Input folder with ISCE swath files for master image or master image file name (in GeoTIFF format and Cartesian coordinates)')
-+                        help='Input folder with ISCE swath files for master image or master image file name '
-+                             '(in GeoTIFF format and Cartesian coordinates)')
-     parser.add_argument('-s', '--input_s', dest='indir_s', type=str, required=True,
--            help='Input folder with ISCE swath files for slave image or slave image file name (in GeoTIFF format and Cartesian coordinates)')
--#    parser.add_argument('-o', '--output', dest='outfile', type=str, default='geogrid.csv',
--#            help='Output grid mapping')
-+                        help='Input folder with ISCE swath files for slave image or slave image file name '
-+                             '(in GeoTIFF format and Cartesian coordinates)')
-+    #    parser.add_argument('-o', '--output', dest='outfile', type=str, default='geogrid.csv',
-+    #            help='Output grid mapping')
-     parser.add_argument('-d', '--dem', dest='demfile', type=str, required=True,
--            help='Input DEM')
-+                        help='Input DEM')
-     parser.add_argument('-sx', '--dhdx', dest='dhdxfile', type=str, default="",
--            help='Input slope in X')
-+                        help='Input slope in X')
-     parser.add_argument('-sy', '--dhdy', dest='dhdyfile', type=str, default="",
--            help='Input slope in Y')
-+                        help='Input slope in Y')
-     parser.add_argument('-vx', '--vx', dest='vxfile', type=str, default="",
--            help='Input velocity in X')
-+                        help='Input velocity in X')
-     parser.add_argument('-vy', '--vy', dest='vyfile', type=str, default="",
--            help='Input velocity in Y')
-+                        help='Input velocity in Y')
-     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
--            help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
-+                        help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
- 
-     return parser.parse_args()
- 
-+
- class Dummy(object):
-     pass
- 
-@@ -64,8 +79,6 @@ def loadProduct(xmlname):
-     '''
-     Load the product using Product Manager.
-     '''
--    import isce
--    from iscesys.Component.ProductManager import ProductManager as PM
- 
-     pm = PM()
-     pm.configure()
-@@ -76,24 +89,20 @@ def loadProduct(xmlname):
- 
- 
- def getMergedOrbit(product):
--    import isce
--    from isceobj.Orbit.Orbit import Orbit
--
-     ###Create merged orbit
-     orb = Orbit()
-     orb.configure()
- 
-     burst = product[0].bursts[0]
--    #Add first burst orbit to begin with
-+    # Add first burst orbit to begin with
-     for sv in burst.orbit:
-         orb.addStateVector(sv)
- 
--
-     for pp in product:
-         ##Add all state vectors
-         for bb in pp.bursts:
-             for sv in bb.orbit:
--                if (sv.time< orb.minTime) or (sv.time > orb.maxTime):
-+                if (sv.time < orb.minTime) or (sv.time > orb.maxTime):
-                     orb.addStateVector(sv)
- 
-     return orb
-@@ -103,11 +112,9 @@ def loadMetadata(indir):
-     '''
-     Input file.
-     '''
--    import os
--    import numpy as np
- 
-     frames = []
--    for swath in range(1,4):
-+    for swath in range(1, 4):
-         inxml = os.path.join(indir, 'IW{0}.xml'.format(swath))
-         if os.path.exists(inxml):
-             ifg = loadProduct(inxml)
-@@ -121,8 +128,8 @@ def loadMetadata(indir):
-     info.prf = 1.0 / frames[0].bursts[0].azimuthTimeInterval
-     info.rangePixelSize = frames[0].bursts[0].rangePixelSize
-     info.lookSide = -1
--    info.numberOfLines = int( np.round( (info.sensingStop - info.sensingStart).total_seconds() * info.prf))
--    info.numberOfSamples = int( np.round( (info.farRange - info.startingRange)/info.rangePixelSize))
-+    info.numberOfLines = int(np.round((info.sensingStop - info.sensingStart).total_seconds() * info.prf))
-+    info.numberOfSamples = int(np.round((info.farRange - info.startingRange) / info.rangePixelSize))
-     info.orbit = getMergedOrbit(frames)
- 
-     return info
-@@ -130,35 +137,27 @@ def loadMetadata(indir):
- 
- def loadMetadataOptical(indir):
-     '''
--        Input file.
--        '''
--    import os
--    import numpy as np
--    
--    from osgeo import gdal, osr
--    import struct
--    
-+    Input file.
-+    '''
-+
-     DS = gdal.Open(indir, gdal.GA_ReadOnly)
-     trans = DS.GetGeoTransform()
--    
-+
-     info = Dummy()
-     info.startingX = trans[0]
-     info.startingY = trans[3]
-     info.XSize = trans[1]
-     info.YSize = trans[5]
--    
-+
-     nameString = os.path.basename(DS.GetDescription())
-     info.time = float(nameString.split('_')[3])
--    
-+
-     info.numberOfLines = DS.RasterYSize
-     info.numberOfSamples = DS.RasterXSize
--    
--    info.filename = indir
--    
--    
--    return info
- 
-+    info.filename = indir
- 
-+    return info
- 
- 
- def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy):
-@@ -166,10 +165,6 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy):
-     Wire and run geogrid.
-     '''
- 
--    import isce
--    from components.contrib.geo_autoRIFT.geogrid import Geogrid
--#     from geogrid import Geogrid
--
-     obj = Geogrid()
-     obj.configure()
- 
-@@ -196,17 +191,13 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy):
-     obj.geogrid()
- 
- 
--
- def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy):
-     '''
--        Wire and run geogrid.
--        '''
-+    Wire and run geogrid.
-+    '''
- 
--    from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
--#    from geogrid import GeogridOptical
--    
-     obj = GeogridOptical()
--    
-+
-     obj.startingX = info.startingX
-     obj.startingY = info.startingY
-     obj.XSize = info.XSize
-@@ -215,7 +206,7 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy):
-     obj.numberOfLines = info.numberOfLines
-     obj.numberOfSamples = info.numberOfSamples
-     obj.nodata_out = -32767
--    
-+
-     obj.dat1name = info.filename
-     obj.demname = dem
-     obj.dhdxname = dhdx
-@@ -226,18 +217,17 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy):
-     obj.winoffname = "window_offset.tif"
-     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
-     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
--    
--    obj.runGeogrid()
- 
-+    obj.runGeogrid()
- 
- 
--if __name__ == '__main__':
-+def main():
-     '''
-     Main driver.
-     '''
- 
-     inps = cmdLineParse()
--    
-+
-     if inps.optical_flag == 1:
-         metadata_m = loadMetadataOptical(inps.indir_m)
-         metadata_s = loadMetadataOptical(inps.indir_s)
-@@ -246,6 +236,7 @@ if __name__ == '__main__':
-         metadata_m = loadMetadata(inps.indir_m)
-         metadata_s = loadMetadata(inps.indir_s)
-         runGeogrid(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile)
--    
- 
- 
-+if __name__ == '__main__':
-+    main()
-diff --git a/hyp3_autorift/vend/testautoRIFT_ISCE.py b/hyp3_autorift/vend/testautoRIFT_ISCE.py
-index 61bd186..f9e1dff 100755
---- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
-+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
-@@ -1,6 +1,11 @@
- #!/usr/bin/env python3
--
 -#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +# This is a substantially modified copy of the testautoRIFT_ISCE.py script
@@ -271,24 +14,16 @@ index 61bd186..f9e1dff 100755
  # Copyright 2019 California Institute of Technology. ALL RIGHTS RESERVED.
  #
  # Licensed under the Apache License, Version 2.0 (the "License");
-@@ -25,36 +30,40 @@
- # embargoed foreign country or citizen of those countries.
+@@ -26,18 +32,24 @@
  #
  # Author: Yang Lei
--#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--
--
--
--
--import pdb
--from osgeo import gdal, osr
-+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +import argparse
 +import logging
 +import subprocess
 +import time
 +from datetime import date
- 
++
 +import cv2
 +import numpy as np
 +import scipy.io as sio
@@ -296,7 +31,14 @@ index 61bd186..f9e1dff 100755
 +from isce.components.isceobj.Util.ImageUtil import ImageLib as IML
 +from osgeo import gdal
  
+-
+-
+-
+-import pdb
+-from osgeo import gdal, osr
+-
 +from hyp3_autorift import netcdf_output as no
+ 
  
  
  def runCmd(cmd):
@@ -304,10 +46,7 @@ index 61bd186..f9e1dff 100755
      out = subprocess.getoutput(cmd)
      return out
  
- 
--
--
- def cmdLineParse():
+@@ -48,7 +60,6 @@
      '''
      Command line parser.
      '''
@@ -315,41 +54,17 @@ index 61bd186..f9e1dff 100755
  
      parser = argparse.ArgumentParser(description='Output geo grid')
      parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
--            help='Input master image file name (in ISCE format and radar coordinates) or Input master image file name (in GeoTIFF format and Cartesian coordinates)')
-+            help='Input master image file name (in ISCE format and radar coordinates) '
-+                 'or Input master image file name (in GeoTIFF format and Cartesian coordinates)')
-     parser.add_argument('-s', '--input_s', dest='indir_s', type=str, required=True,
--            help='Input slave image file name (in ISCE format and radar coordinates) or Input slave image file name (in GeoTIFF format and Cartesian coordinates)')
-+            help='Input slave image file name (in ISCE format and radar coordinates) '
-+                 'or Input slave image file name (in GeoTIFF format and Cartesian coordinates)')
-     parser.add_argument('-g', '--input_g', dest='grid_location', type=str, required=False,
-             help='Input pixel indices file name')
-     parser.add_argument('-o', '--input_o', dest='init_offset', type=str, required=False,
-@@ -68,35 +77,27 @@ def cmdLineParse():
-     parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None,
-             help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
- 
--
-     return parser.parse_args()
- 
-+
- class Dummy(object):
-     pass
- 
- 
--
- def loadProduct(filename):
+@@ -86,9 +97,6 @@
      '''
      Load the product using Product Manager.
      '''
 -    import isce
 -    import logging
 -    from imageMath import IML
--    
+     
      IMG = IML.mmapFromISCE(filename, logging)
      img = IMG.bands[0]
--#    pdb.set_trace()
-     return img
+@@ -97,7 +105,6 @@
  
  
  def loadProductOptical(filename):
@@ -357,159 +72,20 @@ index 61bd186..f9e1dff 100755
      '''
      Load the product using Product Manager.
      '''
-     ds = gdal.Open(filename)
--#    pdb.set_trace()
-     band = ds.GetRasterBand(1)
-     
-     img = band.ReadAsArray()
-@@ -108,28 +109,14 @@ def loadProductOptical(filename):
-     return img
- 
- 
--
--
- def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, noDataMask, optflag, nodata):
-     '''
+@@ -121,12 +128,6 @@
      Wire and run geogrid.
      '''
--
+ 
 -    import isce
 -    from components.contrib.geo_autoRIFT.autoRIFT import autoRIFT_ISCE
 -    import numpy as np
 -    import isceobj
 -    import time
--    
+-    import subprocess
+     
      
      obj = autoRIFT_ISCE()
-     obj.configure()
- 
--#    ##########     uncomment if starting from preprocessed images
--#    I1 = I1.astype(np.uint8)
--#    I2 = I2.astype(np.uint8)
--
--
-     # take the amplitude only for the radar images
-     if optflag == 0:
-         I1 = np.abs(I1)
-@@ -137,8 +124,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, noDataMask, optflag, nodata):
- 
-     obj.I1 = I1
-     obj.I2 = I2
--    
--    
-+
-     # create the grid if it does not exist
-     if xGrid is None:
-         m,n = obj.I1.shape
-@@ -156,25 +142,16 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, noDataMask, optflag, nodata):
-             obj.ChipSizeMaxX = 32
-             obj.ChipSizeMinX = 16
-             obj.ChipSize0X = 16
--
-     
--    # generate the nodata mask where offset searching will be skipped based on 1) imported nodata mask and/or 2) zero values in the image
-+    # generate the nodata mask where offset searching will be skipped based on
-+    # 1) imported nodata mask and/or 2) zero values in the image
-     for ii in range(obj.xGrid.shape[0]):
-         for jj in range(obj.xGrid.shape[1]):
-             if (obj.yGrid[ii,jj] != nodata)&(obj.xGrid[ii,jj] != nodata):
-                 if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
-                     noDataMask[ii,jj] = True
- 
--
--
--
--    ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
--    
--#    ###########     uncomment to customize SearchLimit based on velocity distribution (i.e. Dx0 must not be None)
--#    obj.SearchLimitX = np.int32(4+(25-4)/(np.max(np.abs(Dx0[np.logical_not(noDataMask)]))-np.min(np.abs(Dx0[np.logical_not(noDataMask)])))*(np.abs(Dx0)-np.min(np.abs(Dx0[np.logical_not(noDataMask)]))))
--#    obj.SearchLimitY = 5
--#    ###########
--
-+    # mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
-     obj.SearchLimitX = obj.SearchLimitX * np.logical_not(noDataMask)
-     obj.SearchLimitY = obj.SearchLimitY * np.logical_not(noDataMask)
- 
-@@ -196,104 +173,36 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, noDataMask, optflag, nodata):
-     if optflag == 0:
-         obj.Dy0 = -1 * obj.Dy0
- 
--
--
--    ######## preprocessing
-+    # preprocessing
-     t1 = time.time()
-     print("Pre-process Start!!!")
--#    obj.zeroMask = 1
-     obj.preprocess_filt_hps()
--#    obj.I1 = np.abs(I1)
--#    obj.I2 = np.abs(I2)
-     print("Pre-process Done!!!")
-     print(time.time()-t1)
- 
-     t1 = time.time()
--#    obj.DataType = 0
-     obj.uniform_data_type()
-     print("Uniform Data Type Done!!!")
-     print(time.time()-t1)
- 
--#    obj.sparseSearchSampleRate = 16
--
--
--#    ########## export preprocessed images to files; can be commented out if not debugging
--#
--#    t1 = time.time()
--#
--#    I1 = obj.I1
--#    I2 = obj.I2
--#
--#    length,width = I1.shape
--#
--#    filename1 = 'I1_uint8_hpsnew.off'
--#
--#    slcFid = open(filename1, 'wb')
--#
--#    for yy in range(length):
--#        data = I1[yy,:]
--#        data.astype(np.float32).tofile(slcFid)
--#
--#    slcFid.close()
--#
--#    img = isceobj.createOffsetImage()
--#    img.setFilename(filename1)
--#    img.setBands(1)
--#    img.setWidth(width)
--#    img.setLength(length)
--#    img.setAccessMode('READ')
--#    img.renderHdr()
--#
--#
--#    filename2 = 'I2_uint8_hpsnew.off'
--#
--#    slcFid = open(filename2, 'wb')
--#
--#    for yy in range(length):
--#        data = I2[yy,:]
--#        data.astype(np.float32).tofile(slcFid)
--#
--#    slcFid.close()
--#
--#    img = isceobj.createOffsetImage()
--#    img.setFilename(filename2)
--#    img.setBands(1)
--#    img.setWidth(width)
--#    img.setLength(length)
--#    img.setAccessMode('READ')
--#    img.renderHdr()
--#
--#    print("output Done!!!")
--#    print(time.time()-t1)
--
--
--    ########## run Autorift
-     t1 = time.time()
-     print("AutoRIFT Start!!!")
-     obj.runAutorift()
+@@ -336,7 +337,6 @@
      print("AutoRIFT Done!!!")
      print(time.time()-t1)
  
@@ -517,17 +93,10 @@ index 61bd186..f9e1dff 100755
      kernel = np.ones((3,3),np.uint8)
      noDataMask = cv2.dilate(noDataMask.astype(np.uint8),kernel,iterations = 1)
      noDataMask = noDataMask.astype(np.bool)
- 
--
--    return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask
--
-+    return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.ScaleChipSizeY, \
-+           obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask
+@@ -349,12 +349,10 @@
  
  
--
--
--
+ 
 -if __name__ == '__main__':
 +def main():
      '''
@@ -535,107 +104,34 @@ index 61bd186..f9e1dff 100755
      '''
 -    import numpy as np
 -    import time
--    
+     
      inps = cmdLineParse()
      
-     if inps.optical_flag == 1:
-@@ -335,9 +244,9 @@ if __name__ == '__main__':
-         band=None
-         ds=None
- 
--
--
--    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(data_m, data_s, xGrid, yGrid, Dx0, Dy0, noDataMask, inps.optical_flag, nodata)
-+    Dx, Dy, InterpMask, ChipSizeX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
-+        data_m, data_s, xGrid, yGrid, Dx0, Dy0, noDataMask, inps.optical_flag, nodata
-+    )
- 
-     if inps.optical_flag == 0:
-         Dy = -Dy
-@@ -363,28 +272,13 @@ if __name__ == '__main__':
+@@ -463,7 +461,6 @@
      SEARCHLIMITX[noDataMask] = 0
      SEARCHLIMITY[noDataMask] = 0
  
 -    import scipy.io as sio
      sio.savemat('offset.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX})
  
--#    #####################  Uncomment for debug mode
--#    sio.savemat('debug.mat',{'Dx':DX,'Dy':DY,'InterpMask':INTERPMASK,'ChipSizeX':CHIPSIZEX,'ScaleChipSizeY':ScaleChipSizeY,'SearchLimitX':SEARCHLIMITX,'SearchLimitY':SEARCHLIMITY})
--#    conts = sio.loadmat('debug.mat')
--#    DX = conts['Dx']
--#    DY = conts['Dy']
--#    INTERPMASK = conts['InterpMask']
--#    CHIPSIZEX = conts['ChipSizeX']
--#    ScaleChipSizeY = conts['ScaleChipSizeY']
--#    SEARCHLIMITX = conts['SearchLimitX']
--#    SEARCHLIMITY = conts['SearchLimitY']
--#    #####################
--
-     if inps.grid_location is not None:
--        
- 
-         t1 = time.time()
-         print("Write Outputs Start!!!")
- 
--
-         # Create the GeoTiff
-         driver = gdal.GetDriverByName('GTiff')
- 
-@@ -404,7 +298,6 @@ if __name__ == '__main__':
-         outband.WriteArray(CHIPSIZEX)
-         outband.FlushCache()
- 
--
-         if inps.offset2vx is not None:
-             ds = gdal.Open(inps.offset2vx)
-             band = ds.GetRasterBand(1)
-@@ -437,41 +330,34 @@ if __name__ == '__main__':
-             outband.WriteArray(VY)
-             outband.FlushCache()
-             
--            ########################################################################################
--            ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-+            # netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-             if inps.nc_sensor == "S":
-                 
-                 rangePixelSize = float(str.split(runCmd('fgrep "Range:" testGeogrid.txt'))[2])
-                 prf = float(str.split(runCmd('fgrep "Azimuth:" testGeogrid.txt'))[2])
-                 dt = float(str.split(runCmd('fgrep "Repeat Time:" testGeogrid.txt'))[2])
-                 epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
--                satv = np.array([float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[3]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[4]), float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[5])])
--#                print (str(rangePixelSize)+"      "+str(prf)+"      "+str(satv)+"      "+str(dt))
-+                satv = np.array([float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[3]),
-+                                 float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[4]),
-+                                 float(str.split(runCmd('fgrep "Center Satellite Velocity:" testGeogrid.txt'))[5])])
-                 azimuthPixelSize = np.sqrt(np.sum(satv**2)) / prf
--#                print (str(rangePixelSize)+"      "+str(azimuthPixelSize))
- 
-                 runCmd('topsinsar_filename.py')
--#                import scipy.io as sio
-                 conts = sio.loadmat('topsinsar_filename.mat')
-                 master_filename = conts['master_filename'][0]
-                 slave_filename = conts['slave_filename'][0]
+ #    #####################  Uncomment for debug mode
+@@ -555,7 +552,6 @@
                  master_split = str.split(master_filename,'_')
                  slave_split = str.split(slave_filename,'_')
  
 -                import netcdf_output as no
-                 version = '1.0.4'
+                 version = '1.0.5'
                  pair_type = 'radar'
                  detection_method = 'feature'
-                 coordinates = 'radar'
--#                out_nc_filename = 'Jakobshavn.nc'
-                 out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
-                 out_nc_filename = './' + out_nc_filename
-                 roi_valid_percentage = np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*100.0
-                 CHIPSIZEY = CHIPSIZEX * ScaleChipSizeY
--                
+@@ -568,7 +564,6 @@
+                 
  
--                
+                 
 -                from datetime import date
                  d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
                  d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
                  date_dt_base = d1 - d0
-@@ -483,9 +369,29 @@ if __name__ == '__main__':
+@@ -580,9 +575,29 @@
                      date_ct = d0 + (d1 - d0)/2
                      date_center = date_ct.strftime("%Y%m%d")
              
@@ -668,26 +164,23 @@ index 61bd186..f9e1dff 100755
  
              elif inps.nc_sensor == "L":
                  
-@@ -498,18 +404,15 @@ if __name__ == '__main__':
+@@ -595,7 +610,6 @@
                  master_split = str.split(master_filename,'_')
                  slave_split = str.split(slave_filename,'_')
                  
 -                import netcdf_output as no
-                 version = '1.0.4'
+                 version = '1.0.5'
                  pair_type = 'optical'
                  detection_method = 'feature'
-                 coordinates = 'map'
--#                out_nc_filename = 'Jakobshavn_opt.nc'
-                 out_nc_filename = master_filename[0:-4]+'_'+slave_filename[0:-4]+'.nc'
-                 out_nc_filename = './' + out_nc_filename
+@@ -606,7 +620,6 @@
                  roi_valid_percentage = np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*100.0
-                 CHIPSIZEY = CHIPSIZEX * ScaleChipSizeY
+                 CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
  
 -                from datetime import date
                  d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
                  d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
                  date_dt_base = d1 - d0
-@@ -521,9 +424,35 @@ if __name__ == '__main__':
+@@ -618,9 +631,35 @@
                      date_ct = d0 + (d1 - d0)/2
                      date_center = date_ct.strftime("%Y%m%d")
  
@@ -725,11 +218,132 @@ index 61bd186..f9e1dff 100755
  
              elif inps.nc_sensor is None:
                  print('netCDF packaging not performed')
-@@ -533,3 +462,7 @@ if __name__ == '__main__':
+@@ -630,3 +669,7 @@
  
          print("Write Outputs Done!!!")
          print(time.time()-t1)
 +
 +
++if __name__ == '__main__':
++    main()
+--- testGeogrid_ISCE.orig.py	2020-06-26 08:51:29.390334041 -0800
++++ testGeogrid_ISCE.py	2020-06-26 09:33:55.933819812 -0800
+@@ -1,6 +1,11 @@
+ #!/usr/bin/env python3
+-
+-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++# This is a substantially modified copy of the testGeogrid_ISCE.py script
++# as described in the README.md in this directory. See the LICENSE file in this
++# directory for the original terms and conditions, and CHANGES.diff for a detailed
++# description of the changes. Notice, all changes are released under the terms
++# and conditions of hyp3-autorift's LICENSE.
++# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ # Copyright 2019 California Institute of Technology. ALL RIGHTS RESERVED.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+@@ -26,14 +31,20 @@
+ #
+ # Authors: Piyush Agram, Yang Lei
+ #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++import argparse
++import os
+ 
++import numpy as np
++from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
++from isce.components.contrib.geo_autoRIFT.geogrid import GeogridOptical
++from isce.components.isceobj.Orbit.Orbit import Orbit
++from isce.components.iscesys.Component.ProductManager import ProductManager as PM
++from osgeo import gdal
+ 
+ def cmdLineParse():
+     '''
+     Command line parser.
+     '''
+-    import argparse
+-
+     parser = argparse.ArgumentParser(description='Output geo grid')
+     parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
+             help='Input folder with ISCE swath files for master image or master image file name (in GeoTIFF format and Cartesian coordinates)')
+@@ -78,8 +89,6 @@
+     '''
+     Load the product using Product Manager.
+     '''
+-    import isce
+-    from iscesys.Component.ProductManager import ProductManager as PM
+ 
+     pm = PM()
+     pm.configure()
+@@ -90,9 +99,6 @@
+ 
+ 
+ def getMergedOrbit(product):
+-    import isce
+-    from isceobj.Orbit.Orbit import Orbit
+-
+     ###Create merged orbit
+     orb = Orbit()
+     orb.configure()
+@@ -117,8 +123,6 @@
+     '''
+     Input file.
+     '''
+-    import os
+-    import numpy as np
+ 
+     frames = []
+     for swath in range(1,4):
+@@ -146,11 +150,6 @@
+     '''
+         Input file.
+         '''
+-    import os
+-    import numpy as np
+-    
+-    from osgeo import gdal, osr
+-    import struct
+     
+     DS = gdal.Open(indir, gdal.GA_ReadOnly)
+     trans = DS.GetGeoTransform()
+@@ -180,10 +179,6 @@
+     Wire and run geogrid.
+     '''
+ 
+-    import isce
+-    from components.contrib.geo_autoRIFT.geogrid import Geogrid
+-#     from geogrid import Geogrid
+-
+     obj = Geogrid()
+     obj.configure()
+ 
+@@ -229,7 +224,6 @@
+         Wire and run geogrid.
+         '''
+ 
+-    from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
+ #    from geogrid import GeogridOptical
+     
+     obj = GeogridOptical()
+@@ -270,13 +264,13 @@
+ 
+ 
+ 
+-if __name__ == '__main__':
++def main():
+     '''
+     Main driver.
+     '''
+ 
+     inps = cmdLineParse()
+-    
++
+     if inps.optical_flag == 1:
+         metadata_m = loadMetadataOptical(inps.indir_m)
+         metadata_s = loadMetadataOptical(inps.indir_s)
+@@ -287,4 +281,5 @@
+         runGeogrid(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile, inps.srxfile, inps.sryfile, inps.csminxfile, inps.csminyfile, inps.csmaxxfile, inps.csmaxyfile, inps.ssmfile)
+     
+ 
+-
 +if __name__ == '__main__':
 +    main()

--- a/hyp3_autorift/vend/README.md
+++ b/hyp3_autorift/vend/README.md
@@ -6,7 +6,7 @@ be easily incorporated from a package manager or installed appropriately.
 ## `testautoRIFT_ISCE.py`
 
 This module was provided in the autoRIFT 
-[v1.0.4 release](https://github.com/leiyangleon/autoRIFT/releases/tag/v1.0.4), 
+[v1.0.6 release](https://github.com/leiyangleon/autoRIFT/releases/tag/v1.0.6),
 and is required for the  expected workflow provided to ASF. However, in its 
 original form, required too many unpackaged or distributed modules to be found
 in the global namespace and therefore cannot be easily incorporated into this
@@ -16,11 +16,11 @@ packaging and distribution of the plugin.
 ## `testGeogrid_ISCE.py`
 
 This module/script is required for the expected workflow provided to ASF, but is
-not provided in the autoRIFT v1.0.4 release and instead resides in the "sister" 
+not provided in the autoRIFT v1.0.6 release and instead resides in the "sister"
 Geogrid package (https://github.com/leiyangleon/Geogrid). Geogrid and autoRIFT
 are exact duplicate packages and only differ in the README and test scripts, so 
 simply installing Geogrid was not an option, and furthermore, the Geogrid
-repository (no longer) has any tagged or released versions, so this script 
-corresponds to the phantom Geogrid v1.0.4 release, which is commit `87ff1e7`. 
+repository (no longer) has any tagged or released versions. This script
+corresponds to the phantom Geogrid v1.0.5 release, which is commit `28358c7`.
 Changes, as listed in `CHANGES.diff`, were done to facilitate better 
 packaging and distribution of the plugin. 

--- a/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -30,13 +30,16 @@
 # embargoed foreign country or citizen of those countries.
 #
 # Authors: Piyush Agram, Yang Lei
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import argparse
 import os
 
 import numpy as np
+from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
+from isce.components.contrib.geo_autoRIFT.geogrid import GeogridOptical
+from isce.components.isceobj.Orbit.Orbit import Orbit
+from isce.components.iscesys.Component.ProductManager import ProductManager as PM
 from osgeo import gdal
-
 
 def cmdLineParse():
     '''
@@ -44,28 +47,39 @@ def cmdLineParse():
     '''
     parser = argparse.ArgumentParser(description='Output geo grid')
     parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
-                        help='Input folder with ISCE swath files for master image or master image file name '
-                             '(in GeoTIFF format and Cartesian coordinates)')
+            help='Input folder with ISCE swath files for master image or master image file name (in GeoTIFF format and Cartesian coordinates)')
     parser.add_argument('-s', '--input_s', dest='indir_s', type=str, required=True,
-                        help='Input folder with ISCE swath files for slave image or slave image file name '
-                             '(in GeoTIFF format and Cartesian coordinates)')
-    #    parser.add_argument('-o', '--output', dest='outfile', type=str, default='geogrid.csv',
-    #            help='Output grid mapping')
+            help='Input folder with ISCE swath files for slave image or slave image file name (in GeoTIFF format and Cartesian coordinates)')
+#    parser.add_argument('-o', '--output', dest='outfile', type=str, default='geogrid.csv',
+#            help='Output grid mapping')
     parser.add_argument('-d', '--dem', dest='demfile', type=str, required=True,
-                        help='Input DEM')
+            help='Input DEM')
     parser.add_argument('-sx', '--dhdx', dest='dhdxfile', type=str, default="",
-                        help='Input slope in X')
+            help='Input slope in X')
     parser.add_argument('-sy', '--dhdy', dest='dhdyfile', type=str, default="",
-                        help='Input slope in Y')
+            help='Input slope in Y')
     parser.add_argument('-vx', '--vx', dest='vxfile', type=str, default="",
-                        help='Input velocity in X')
+            help='Input velocity in X')
     parser.add_argument('-vy', '--vy', dest='vyfile', type=str, default="",
-                        help='Input velocity in Y')
+            help='Input velocity in Y')
+    parser.add_argument('-srx', '--srx', dest='srxfile', type=str, default="",
+            help='Input search range in X')
+    parser.add_argument('-sry', '--sry', dest='sryfile', type=str, default="",
+            help='Input search range in Y')
+    parser.add_argument('-csminx', '--csminx', dest='csminxfile', type=str, default="",
+            help='Input chip size min in X')
+    parser.add_argument('-csminy', '--csminy', dest='csminyfile', type=str, default="",
+            help='Input chip size min in Y')
+    parser.add_argument('-csmaxx', '--csmaxx', dest='csmaxxfile', type=str, default="",
+            help='Input chip size max in X')
+    parser.add_argument('-csmaxy', '--csmaxy', dest='csmaxyfile', type=str, default="",
+            help='Input chip size max in Y')
+    parser.add_argument('-ssm', '--ssm', dest='ssmfile', type=str, default="",
+            help='Input stable surface mask')
     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
-                        help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
+            help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
 
     return parser.parse_args()
-
 
 class Dummy(object):
     pass
@@ -75,8 +89,6 @@ def loadProduct(xmlname):
     '''
     Load the product using Product Manager.
     '''
-    import isce
-    from iscesys.Component.ProductManager import ProductManager as PM
 
     pm = PM()
     pm.configure()
@@ -88,21 +100,20 @@ def loadProduct(xmlname):
 
 def getMergedOrbit(product):
     ###Create merged orbit
-    import isce
-    from isceobj.Orbit.Orbit import Orbit
     orb = Orbit()
     orb.configure()
 
     burst = product[0].bursts[0]
-    # Add first burst orbit to begin with
+    #Add first burst orbit to begin with
     for sv in burst.orbit:
         orb.addStateVector(sv)
+
 
     for pp in product:
         ##Add all state vectors
         for bb in pp.bursts:
             for sv in bb.orbit:
-                if (sv.time < orb.minTime) or (sv.time > orb.maxTime):
+                if (sv.time< orb.minTime) or (sv.time > orb.maxTime):
                     orb.addStateVector(sv)
 
     return orb
@@ -114,7 +125,7 @@ def loadMetadata(indir):
     '''
 
     frames = []
-    for swath in range(1, 4):
+    for swath in range(1,4):
         inxml = os.path.join(indir, 'IW{0}.xml'.format(swath))
         if os.path.exists(inxml):
             ifg = loadProduct(inxml)
@@ -128,8 +139,8 @@ def loadMetadata(indir):
     info.prf = 1.0 / frames[0].bursts[0].azimuthTimeInterval
     info.rangePixelSize = frames[0].bursts[0].rangePixelSize
     info.lookSide = -1
-    info.numberOfLines = int(np.round((info.sensingStop - info.sensingStart).total_seconds() * info.prf))
-    info.numberOfSamples = int(np.round((info.farRange - info.startingRange) / info.rangePixelSize))
+    info.numberOfLines = int( np.round( (info.sensingStop - info.sensingStart).total_seconds() * info.prf))
+    info.numberOfSamples = int( np.round( (info.farRange - info.startingRange)/info.rangePixelSize))
     info.orbit = getMergedOrbit(frames)
 
     return info
@@ -137,8 +148,8 @@ def loadMetadata(indir):
 
 def loadMetadataOptical(indir):
     '''
-    Input file.
-    '''
+        Input file.
+        '''
 
     DS = gdal.Open(indir, gdal.GA_ReadOnly)
     trans = DS.GetGeoTransform()
@@ -157,15 +168,17 @@ def loadMetadataOptical(indir):
 
     info.filename = indir
 
+
     return info
 
 
-def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy):
+
+
+def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, csmaxx, csmaxy, ssm):
     '''
     Wire and run geogrid.
     '''
-    import isce
-    from components.contrib.geo_autoRIFT.geogrid import Geogrid
+
     obj = Geogrid()
     obj.configure()
 
@@ -178,29 +191,43 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy):
     obj.numberOfLines = info.numberOfLines
     obj.numberOfSamples = info.numberOfSamples
     obj.nodata_out = -32767
+    obj.chipSizeX0 = 240
     obj.orbit = info.orbit
     obj.demname = dem
     obj.dhdxname = dhdx
     obj.dhdyname = dhdy
     obj.vxname = vx
     obj.vyname = vy
+    obj.srxname = srx
+    obj.sryname = sry
+    obj.csminxname = csminx
+    obj.csminyname = csminy
+    obj.csmaxxname = csmaxx
+    obj.csmaxyname = csmaxy
+    obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
+    obj.winsrname = "window_search_range.tif"
+    obj.wincsminname = "window_chip_size_min.tif"
+    obj.wincsmaxname = "window_chip_size_max.tif"
+    obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
-
+    
+    obj.getIncidenceAngle()
     obj.geogrid()
 
 
-def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy):
-    '''
-    Wire and run geogrid.
-    '''
-    import isce
-    from components.contrib.geo_autoRIFT.geogrid import GeogridOptical
 
+def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, csmaxx, csmaxy, ssm):
+    '''
+        Wire and run geogrid.
+        '''
+
+#    from geogrid import GeogridOptical
+    
     obj = GeogridOptical()
-
+    
     obj.startingX = info.startingX
     obj.startingY = info.startingY
     obj.XSize = info.XSize
@@ -209,19 +236,32 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy):
     obj.numberOfLines = info.numberOfLines
     obj.numberOfSamples = info.numberOfSamples
     obj.nodata_out = -32767
-
+    obj.chipSizeX0 = 240
+    
     obj.dat1name = info.filename
     obj.demname = dem
     obj.dhdxname = dhdx
     obj.dhdyname = dhdy
     obj.vxname = vx
     obj.vyname = vy
+    obj.srxname = srx
+    obj.sryname = sry
+    obj.csminxname = csminx
+    obj.csminyname = csminy
+    obj.csmaxxname = csmaxx
+    obj.csmaxyname = csmaxy
+    obj.ssmname = ssm
     obj.winlocname = "window_location.tif"
     obj.winoffname = "window_offset.tif"
+    obj.winsrname = "window_search_range.tif"
+    obj.wincsminname = "window_chip_size_min.tif"
+    obj.wincsmaxname = "window_chip_size_max.tif"
+    obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
 
     obj.runGeogrid()
+
 
 
 def main():
@@ -234,12 +274,12 @@ def main():
     if inps.optical_flag == 1:
         metadata_m = loadMetadataOptical(inps.indir_m)
         metadata_s = loadMetadataOptical(inps.indir_s)
-        runGeogridOptical(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile)
+        runGeogridOptical(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile, inps.srxfile, inps.sryfile, inps.csminxfile, inps.csminyfile, inps.csmaxxfile, inps.csmaxyfile, inps.ssmfile)
     else:
         metadata_m = loadMetadata(inps.indir_m)
         metadata_s = loadMetadata(inps.indir_s)
-        runGeogrid(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile)
-
+        runGeogrid(metadata_m, metadata_s, inps.demfile, inps.dhdxfile, inps.dhdyfile, inps.vxfile, inps.vyfile, inps.srxfile, inps.sryfile, inps.csminxfile, inps.csminyfile, inps.csmaxxfile, inps.csmaxyfile, inps.ssmfile)
+    
 
 if __name__ == '__main__':
     main()

--- a/hyp3_autorift/vend/testGeogrid_ISCE.py
+++ b/hyp3_autorift/vend/testGeogrid_ISCE.py
@@ -35,10 +35,11 @@ import argparse
 import os
 
 import numpy as np
-from isce.components.contrib.geo_autoRIFT.geogrid import Geogrid
-from isce.components.contrib.geo_autoRIFT.geogrid import GeogridOptical
-from isce.components.isceobj.Orbit.Orbit import Orbit
-from isce.components.iscesys.Component.ProductManager import ProductManager as PM
+import isce
+from contrib.geo_autoRIFT.geogrid import Geogrid
+from contrib.geo_autoRIFT.geogrid import GeogridOptical
+from isceobj.Orbit.Orbit import Orbit
+from iscesys.Component.ProductManager import ProductManager as PM
 from osgeo import gdal
 
 def cmdLineParse():

--- a/hyp3_autorift/vend/testautoRIFT_ISCE.py
+++ b/hyp3_autorift/vend/testautoRIFT_ISCE.py
@@ -40,8 +40,9 @@ from datetime import date
 import cv2
 import numpy as np
 import scipy.io as sio
-from isce.components.contrib.geo_autoRIFT.autoRIFT import autoRIFT_ISCE
-from isce.components.isceobj.Util.ImageUtil import ImageLib as IML
+import isce
+from contrib.geo_autoRIFT.autoRIFT import autoRIFT_ISCE
+from isceobj.Util.ImageUtil import ImageLib as IML
 from osgeo import gdal
 
 from hyp3_autorift import netcdf_output as no


### PR DESCRIPTION
This updates the autoRIFT version from `v1.0.4`, which needed to be manually installed into ISCE, to the latest conda-forge version of ISCE (v2.3.3) that includes autoRIFT `v1.0.6`. 

autoRIFT `v1.0.4` --> `v1.0.6` is API breaking, so so required a workflow update. 

Also included is the ability to select *just* the netCDF output as the product, or zip all the intermediate autoRIFT files with the netCDF as the product (for testing/validation). 